### PR TITLE
Catch Undefined Error for Unknown Cities

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
 import { memoize } from 'cerebro-tools'
-import { head, prop, curry } from 'ramda'
+import { head, prop, curry, tryCatch } from 'ramda'
 
 const BASE_URL = 'https://www.metaweather.com/api/location'
 
@@ -20,6 +20,6 @@ const decode = response => response.json()
 export const getWeather = city => (
   searchCity(city)
     .then(head)
-    .then(prop('woeid'))
+    .then(tryCatch(prop('woeid'), () => Promise.reject(`Can't find weather for ${city}`)))
     .then(getCityWeather)
 )

--- a/src/api.js
+++ b/src/api.js
@@ -17,9 +17,12 @@ const getCityWeather = memoize(
 
 const decode = response => response.json()
 
-export const getWeather = city => (
+export const getWeather = city =>
   searchCity(city)
     .then(head)
-    .then(tryCatch(prop('woeid'), () => Promise.reject(`Can't find weather for ${city}`)))
+    .then(
+      tryCatch(prop('woeid'), () =>
+        Promise.reject(`Can't find weather for ${city}`)
+      )
+    )
     .then(getCityWeather)
-)

--- a/src/preview.js
+++ b/src/preview.js
@@ -17,12 +17,14 @@ export default class Preview extends Component {
     super(props)
     this.state = {
       weather: null,
-      error: null
+      error: null,
     }
   }
 
   componentDidMount() {
-    getWeather(this.props.city).then(weather => this.setState({ weather })).catch((error) => this.setState({ error }))
+    getWeather(this.props.city)
+      .then(weather => this.setState({ weather }))
+      .catch(error => this.setState({ error }))
   }
 
   renderTags() {

--- a/src/preview.js
+++ b/src/preview.js
@@ -17,11 +17,12 @@ export default class Preview extends Component {
     super(props)
     this.state = {
       weather: null,
+      error: null
     }
   }
 
   componentDidMount() {
-    getWeather(this.props.city).then(weather => this.setState({ weather }))
+    getWeather(this.props.city).then(weather => this.setState({ weather })).catch((error) => this.setState({ error }))
   }
 
   renderTags() {
@@ -41,8 +42,8 @@ export default class Preview extends Component {
   }
 
   render() {
-    if (!this.state.weather) return <div>Loading...</div>
-
+    if (!this.state.weather && !this.state.error) return <div>Loading...</div>
+    else if (this.state.error) return <div>Error: {this.state.error}</div>
     const weatherReports = this.state.weather.consolidated_weather
 
     return (


### PR DESCRIPTION
When the source API doesn't return a city, return and display a simple error message in the preview window.

In response to issue #4 